### PR TITLE
Attestations fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ ENV PIP_ROOT_USER_ACTION ignore
 ENV PATH "/root/.local/bin:${PATH}"
 ENV PYTHONPATH "/root/.local/lib/python3.12/site-packages"
 
-# NOTE: Temporary; to be removed once a new twine is released.
-RUN apt-get update && apt-get install -y git
-
 COPY requirements requirements
 RUN \
   PIP_CONSTRAINT=requirements/runtime-prerequisites.txt \

--- a/README.md
+++ b/README.md
@@ -246,6 +246,25 @@ for example. See [Creating & using secrets]. While still secure,
 [trusted publishing] is now encouraged over API tokens as a best practice
 on supported platforms (like GitHub).
 
+### Generating and uploading attestations (EXPERIMENTAL)
+
+> [!NOTE]
+> Support for generating and uploading [PEP 740 attestations] is currently
+> experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
+
+You can generate signed [PEP 740 attestations] for all the distribution files and
+upload them all together by enabling the `attestations` setting:
+
+```yml
+   with:
+     attestations: true
+```
+
+This will use `sigstore` to create attestation objects for each distribution package,
+signing them with the identity provided by the GitHub's OIDC token associated with the
+current workflow. This means both the trusted publishing authentication and the
+attestations are tied to the same identity.
+
 ## License
 
 The Dockerfile and associated scripts and documentation in this project
@@ -287,3 +306,5 @@ https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md
 [configured on PyPI]: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
 
 [how to specify username and password]: #specifying-a-different-username
+
+[PEP 740 attestations]: https://peps.python.org/pep-0740/

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,7 +1,4 @@
-# NOTE: Temporarily pulling directly from GitHub for the attestations feature,
-# which is not yet released.
-# See: https://github.com/pypa/twine/issues/1094
-twine @ git+https://github.com/pypa/twine@5d17a43dec622d6f4fc490937baad3db4b9a8e29
+twine
 
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
 # as well as PEP 740 attestations.

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -13,5 +13,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestation-models == 0.0.1rc2
+pypi-attestation-models == 0.0.1
 sigstore ~= 3.0.0rc2

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -119,7 +119,7 @@ six==1.16.0
     # via python-dateutil
 tuf==4.0.0
     # via sigstore
-twine @ git+https://github.com/pypa/twine@5d17a43dec622d6f4fc490937baad3db4b9a8e29
+twine==5.1.0
     # via -r runtime.in
 typing-extensions==4.10.0
     # via

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -81,7 +81,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestation-models==0.0.1rc2
+pypi-attestation-models==0.0.1
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -69,6 +69,7 @@ if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
     # user confusion, since attestations (currently) require Trusted Publishing.
     if [[ -n "${INPUT_PASSWORD}" ]] ; then
         echo "${ATTESTATIONS_WITHOUT_TP_WARNING}"
+        INPUT_ATTESTATIONS="false"
     fi
 
     # Setting `attestations: true` with an index other than PyPI or TestPyPI
@@ -76,6 +77,7 @@ if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
     # indices presently.
     if [[ ! "${INPUT_REPOSITORY_URL}" =~ pypi\.org ]] ; then
         echo "${ATTESTATIONS_WRONG_INDEX_WARNING}"
+        INPUT_ATTESTATIONS="false"
     fi
 fi
 


### PR DESCRIPTION
- Add documentation to README
- Update `pypi-attestation-models`
- Actually ignore the `attestation` setting when the workflow does not use trusted publishing, or when the index is not PyPI/TestPyPI
- Go back to using the latest `twine` released version, now that `5.1.0` was released